### PR TITLE
Add Duco integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -411,6 +411,8 @@ build.json @home-assistant/supervisor
 /tests/components/dsmr_reader/ @sorted-bits @glodenox @erwindouna
 /homeassistant/components/duckdns/ @tr4nt0r
 /tests/components/duckdns/ @tr4nt0r
+/homeassistant/components/duco/ @ronaldvdmeer
+/tests/components/duco/ @ronaldvdmeer
 /homeassistant/components/duotecno/ @cereal2nd
 /tests/components/duotecno/ @cereal2nd
 /homeassistant/components/dwd_weather_warnings/ @runningman84 @stephan192

--- a/homeassistant/components/duco/__init__.py
+++ b/homeassistant/components/duco/__init__.py
@@ -1,0 +1,45 @@
+"""The Duco integration."""
+
+from __future__ import annotations
+
+from duco import DucoClient
+from duco.exceptions import DucoConnectionError, DucoError
+
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import PLATFORMS
+from .coordinator import DucoConfigEntry, DucoCoordinator
+
+__all__ = ["DucoConfigEntry"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: DucoConfigEntry) -> bool:
+    """Set up Duco from a config entry."""
+    client = DucoClient(
+        session=async_get_clientsession(hass),
+        host=entry.data[CONF_HOST],
+    )
+
+    try:
+        board_info = await client.async_get_board_info()
+    except (DucoConnectionError, DucoError) as err:
+        raise ConfigEntryNotReady(
+            f"Cannot connect to Duco box at {entry.data[CONF_HOST]}: {err}"
+        ) from err
+
+    coordinator = DucoCoordinator(hass, entry, client, board_info)
+    await coordinator.async_config_entry_first_refresh()
+
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: DucoConfigEntry) -> bool:
+    """Unload a Duco config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -1,0 +1,59 @@
+"""Config flow for the Duco integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from duco import DucoClient
+from duco.exceptions import DucoConnectionError, DucoError
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+STEP_USER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+    }
+)
+
+
+class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Config flow for Duco."""
+
+    VERSION = 1
+    MINOR_VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            client = DucoClient(
+                session=async_get_clientsession(self.hass),
+                host=user_input[CONF_HOST],
+            )
+            try:
+                board_info = await client.async_get_board_info()
+                lan_info = await client.async_get_lan_info()
+            except DucoConnectionError, DucoError:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(lan_info.mac)
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=board_info.box_name,
+                    data={CONF_HOST: user_input[CONF_HOST]},
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_SCHEMA,
+            errors=errors,
+        )

--- a/homeassistant/components/duco/config_flow.py
+++ b/homeassistant/components/duco/config_flow.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 
 from .const import DOMAIN
 
@@ -44,7 +45,7 @@ class DucoConfigFlow(ConfigFlow, domain=DOMAIN):
             except DucoConnectionError, DucoError:
                 errors["base"] = "cannot_connect"
             else:
-                await self.async_set_unique_id(lan_info.mac)
+                await self.async_set_unique_id(format_mac(lan_info.mac))
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(

--- a/homeassistant/components/duco/const.py
+++ b/homeassistant/components/duco/const.py
@@ -1,0 +1,9 @@
+"""Constants for the Duco integration."""
+
+from datetime import timedelta
+
+from homeassistant.const import Platform
+
+DOMAIN = "duco"
+PLATFORMS = [Platform.FAN, Platform.SENSOR]
+SCAN_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -1,0 +1,52 @@
+"""Data update coordinator for the Duco integration."""
+
+from __future__ import annotations
+
+import logging
+
+from duco import DucoClient
+from duco.exceptions import DucoConnectionError, DucoError
+from duco.models import BoardInfo, Node
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+type DucoConfigEntry = ConfigEntry[DucoCoordinator]
+
+
+class DucoCoordinator(DataUpdateCoordinator[list[Node]]):
+    """Coordinator for the Duco integration."""
+
+    config_entry: DucoConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: DucoConfigEntry,
+        client: DucoClient,
+        board_info: BoardInfo,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+        self.client = client
+        self.board_info = board_info
+
+    async def _async_update_data(self) -> list[Node]:
+        """Fetch node data from the Duco box."""
+        try:
+            return await self.client.async_get_nodes()
+        except DucoConnectionError as err:
+            raise UpdateFailed(f"Cannot connect to Duco box: {err}") from err
+        except DucoError as err:
+            raise UpdateFailed(f"Duco API error: {err}") from err

--- a/homeassistant/components/duco/entity.py
+++ b/homeassistant/components/duco/entity.py
@@ -1,0 +1,28 @@
+"""Base entity for the Duco integration."""
+
+from __future__ import annotations
+
+from duco.models import Node
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import DucoCoordinator
+
+
+class DucoEntity(CoordinatorEntity[DucoCoordinator]):
+    """Base class for Duco entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: DucoCoordinator, node_id: int) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._node_id = node_id
+
+    @property
+    def _node(self) -> Node | None:
+        """Return the current node data from the coordinator."""
+        return next(
+            (n for n in self.coordinator.data if n.node_id == self._node_id),
+            None,
+        )

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -39,7 +39,7 @@ _PRESET_TO_STATE: dict[str, VentilationState] = {
     PRESET_HIGH_FORCED: VentilationState.CNT3,
 }
 
-_STATE_TO_PRESET: dict[str, str] = {
+_STATE_TO_PRESET: dict[VentilationState, str] = {
     VentilationState.AUTO: PRESET_AUTO,
     VentilationState.AUT1: PRESET_AUTO,
     VentilationState.AUT2: PRESET_AUTO,

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -131,6 +131,8 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the ventilation preset mode."""
+        if preset_mode not in _PRESET_TO_STATE:
+            raise HomeAssistantError(f"Invalid preset mode: {preset_mode}")
         # Optimistically update the UI immediately.
         self._attr_preset_mode = preset_mode
         self.async_write_ha_state()

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -1,0 +1,168 @@
+"""Fan platform for the Duco integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from duco.exceptions import DucoError
+from duco.models import Node, VentilationState
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import DucoConfigEntry, DucoCoordinator
+from .entity import DucoEntity
+
+PARALLEL_UPDATES = 0
+
+PRESET_AUTO = "auto"
+PRESET_AWAY = "away"
+PRESET_LOW = "low"
+PRESET_LOW_FORCED = "low_forced"
+PRESET_MEDIUM = "medium"
+PRESET_MEDIUM_FORCED = "medium_forced"
+PRESET_HIGH = "high"
+PRESET_HIGH_FORCED = "high_forced"
+
+_PRESET_TO_STATE: dict[str, VentilationState] = {
+    PRESET_AUTO: VentilationState.AUTO,
+    PRESET_AWAY: VentilationState.EMPT,
+    PRESET_LOW: VentilationState.MAN1,
+    PRESET_LOW_FORCED: VentilationState.CNT1,
+    PRESET_MEDIUM: VentilationState.MAN2,
+    PRESET_MEDIUM_FORCED: VentilationState.CNT2,
+    PRESET_HIGH: VentilationState.MAN3,
+    PRESET_HIGH_FORCED: VentilationState.CNT3,
+}
+
+_STATE_TO_PRESET: dict[str, str] = {
+    VentilationState.AUTO: PRESET_AUTO,
+    VentilationState.AUT1: PRESET_AUTO,
+    VentilationState.AUT2: PRESET_AUTO,
+    VentilationState.AUT3: PRESET_AUTO,
+    VentilationState.EMPT: PRESET_AWAY,
+    VentilationState.MAN1: PRESET_LOW,
+    VentilationState.MAN1x2: PRESET_LOW,
+    VentilationState.MAN1x3: PRESET_LOW,
+    VentilationState.CNT1: PRESET_LOW_FORCED,
+    VentilationState.MAN2: PRESET_MEDIUM,
+    VentilationState.MAN2x2: PRESET_MEDIUM,
+    VentilationState.MAN2x3: PRESET_MEDIUM,
+    VentilationState.CNT2: PRESET_MEDIUM_FORCED,
+    VentilationState.MAN3: PRESET_HIGH,
+    VentilationState.MAN3x2: PRESET_HIGH,
+    VentilationState.MAN3x3: PRESET_HIGH,
+    VentilationState.CNT3: PRESET_HIGH_FORCED,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: DucoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Duco fan entities."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        DucoVentilationFanEntity(coordinator, node)
+        for node in coordinator.data
+        if node.ventilation is not None
+    )
+
+
+class DucoVentilationFanEntity(DucoEntity, FanEntity):
+    """Fan entity for the ventilation control of a Duco node."""
+
+    _attr_translation_key = "ventilation"
+    _attr_preset_modes = [
+        PRESET_AUTO,
+        PRESET_AWAY,
+        PRESET_LOW,
+        PRESET_LOW_FORCED,
+        PRESET_MEDIUM,
+        PRESET_MEDIUM_FORCED,
+        PRESET_HIGH,
+        PRESET_HIGH_FORCED,
+    ]
+    _attr_supported_features = (
+        FanEntityFeature.PRESET_MODE
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, coordinator: DucoCoordinator, node: Node) -> None:
+        """Initialize the fan entity."""
+        super().__init__(coordinator, node.node_id)
+        mac = coordinator.config_entry.unique_id
+        self._attr_unique_id = f"{mac}_{node.node_id}_ventilation"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{mac}_{node.node_id}")},
+            manufacturer="Duco",
+            model=coordinator.board_info.box_name
+            if node.general.node_type == "BOX"
+            else node.general.node_type,
+            name=node.general.name or f"Node {node.node_id}",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True always; the fan is always running physically."""
+        return True
+
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic state on coordinator update."""
+        self._attr_preset_mode = None
+        super()._handle_coordinator_update()
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current preset mode."""
+        if self._attr_preset_mode is not None:
+            return self._attr_preset_mode
+        node = self._node
+        if node is None or node.ventilation is None:
+            return None
+        return _STATE_TO_PRESET.get(node.ventilation.state)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Set the ventilation preset mode."""
+        # Optimistically update the UI immediately.
+        self._attr_preset_mode = preset_mode
+        self.async_write_ha_state()
+        await self._async_set_state(_PRESET_TO_STATE[preset_mode])
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Switch to manual ventilation (default: medium)."""
+        target = preset_mode or PRESET_MEDIUM
+        self._attr_preset_mode = target
+        self.async_write_ha_state()
+        await self._async_set_state(_PRESET_TO_STATE[target])
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Return to automatic ventilation control."""
+        self._attr_preset_mode = PRESET_AUTO
+        self.async_write_ha_state()
+        await self._async_set_state(VentilationState.AUTO)
+
+    async def _async_set_state(self, state: VentilationState) -> None:
+        """Send the ventilation state to the device and refresh coordinator."""
+        try:
+            await self.coordinator.client.async_set_ventilation_state(
+                self._node_id, state
+            )
+        except DucoError as err:
+            # Revert optimistic state on failure.
+            self._attr_preset_mode = None
+            self.async_write_ha_state()
+            raise HomeAssistantError(f"Failed to set ventilation state: {err}") from err
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/duco/fan.py
+++ b/homeassistant/components/duco/fan.py
@@ -144,6 +144,8 @@ class DucoVentilationFanEntity(DucoEntity, FanEntity):
     ) -> None:
         """Switch to manual ventilation (default: medium)."""
         target = preset_mode or PRESET_MEDIUM
+        if target not in _PRESET_TO_STATE:
+            raise HomeAssistantError(f"Invalid preset mode: {target}")
         self._attr_preset_mode = target
         self.async_write_ha_state()
         await self._async_set_state(_PRESET_TO_STATE[target])

--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "duco",
+  "name": "Duco",
+  "codeowners": ["@ronaldvdmeer"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/duco",
+  "integration_type": "hub",
+  "iot_class": "local_polling",
+  "loggers": ["duco"],
+  "quality_scale": "bronze",
+  "requirements": ["python-duco-client==0.1.0"]
+}

--- a/homeassistant/components/duco/manifest.json
+++ b/homeassistant/components/duco/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["duco"],
   "quality_scale": "bronze",
-  "requirements": ["python-duco-client==0.1.0"]
+  "requirements": ["python-duco-client==0.2.0"]
 }

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -1,0 +1,84 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: Integration does not provide service actions.
+  appropriate-polling: done
+  brands:
+    status: exempt
+    comment: Brands are managed in the home-assistant/brands repository.
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: Integration does not provide service actions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  entity-event-setup:
+    status: exempt
+    comment: Integration uses a coordinator; entities do not subscribe to events directly.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: Integration does not provide service actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: Integration does not provide an option flow.
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable:
+    status: done
+    comment: Handled by the DataUpdateCoordinator.
+  parallel-updates: done
+  reauthentication-flow:
+    status: exempt
+    comment: Integration uses a local API that requires no credentials.
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: Integration does not support automatic discovery.
+  discovery:
+    status: exempt
+    comment: Integration does not support automatic discovery.
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: The node topology of a Duco box is fixed and does not change at runtime.
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: done
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices:
+    status: exempt
+    comment: Nodes are fixed; stale device cleanup is not applicable.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -4,9 +4,7 @@ rules:
     status: exempt
     comment: Integration does not provide service actions.
   appropriate-polling: done
-  brands:
-    status: exempt
-    comment: Brands are managed in the home-assistant/brands repository.
+  brands: done
   common-modules: done
   config-flow-test-coverage: done
   config-flow: done

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -1,0 +1,59 @@
+"""Sensor platform for the Duco integration."""
+
+from __future__ import annotations
+
+from duco.models import Node
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import DucoConfigEntry, DucoCoordinator
+from .entity import DucoEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: DucoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Duco sensor entities."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        DucoVentilationStateSensor(coordinator, node)
+        for node in coordinator.data
+        if node.ventilation is not None
+    )
+
+
+class DucoVentilationStateSensor(DucoEntity, SensorEntity):
+    """Sensor entity showing the raw Duco ventilation state."""
+
+    _attr_translation_key = "ventilation_state"
+
+    def __init__(self, coordinator: DucoCoordinator, node: Node) -> None:
+        """Initialize the sensor entity."""
+        super().__init__(coordinator, node.node_id)
+        mac = coordinator.config_entry.unique_id
+        self._attr_unique_id = f"{mac}_{node.node_id}_ventilation_state"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{mac}_{node.node_id}")},
+            manufacturer="Duco",
+            model=coordinator.board_info.box_name
+            if node.general.node_type == "BOX"
+            else node.general.node_type,
+            name=node.general.name or f"Node {node.node_id}",
+        )
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current ventilation state."""
+        node = self._node
+        if node is None or node.ventilation is None:
+            return None
+        return node.ventilation.state

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -56,4 +56,4 @@ class DucoVentilationStateSensor(DucoEntity, SensorEntity):
         node = self._node
         if node is None or node.ventilation is None:
             return None
-        return node.ventilation.state
+        return str(node.ventilation.state)

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -9,7 +9,7 @@
     "step": {
       "user": {
         "data": {
-          "host": "Host"
+          "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
           "host": "IP address or hostname of your Duco ventilation box."

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -1,0 +1,46 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host"
+        },
+        "data_description": {
+          "host": "IP address or hostname of your Duco ventilation box."
+        }
+      }
+    }
+  },
+  "entity": {
+    "fan": {
+      "ventilation": {
+        "name": "Ventilation",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto",
+              "away": "Away",
+              "high": "High",
+              "high_forced": "High (permanent)",
+              "low": "Low",
+              "low_forced": "Low (permanent)",
+              "medium": "Medium",
+              "medium_forced": "Medium (permanent)"
+            }
+          }
+        }
+      }
+    },
+    "sensor": {
+      "ventilation_state": {
+        "name": "Ventilation state"
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -165,6 +165,7 @@ FLOWS = {
         "dsmr",
         "dsmr_reader",
         "duckdns",
+        "duco",
         "dunehd",
         "duotecno",
         "dwd_weather_warnings",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1521,6 +1521,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "duco": {
+      "name": "Duco",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "dunehd": {
       "name": "Dune HD",
       "integration_type": "device",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2572,7 +2572,7 @@ python-digitalocean==1.13.2
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.1.0
+python-duco-client==0.2.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2571,6 +2571,9 @@ python-digitalocean==1.13.2
 # homeassistant.components.dropbox
 python-dropbox-api==0.1.3
 
+# homeassistant.components.duco
+python-duco-client==0.1.0
+
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2191,6 +2191,9 @@ python-bsblan==5.1.3
 # homeassistant.components.dropbox
 python-dropbox-api==0.1.3
 
+# homeassistant.components.duco
+python-duco-client==0.1.0
+
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2192,7 +2192,7 @@ python-bsblan==5.1.3
 python-dropbox-api==0.1.3
 
 # homeassistant.components.duco
-python-duco-client==0.1.0
+python-duco-client==0.2.0
 
 # homeassistant.components.ecobee
 python-ecobee-api==0.3.2

--- a/tests/components/duco/__init__.py
+++ b/tests/components/duco/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Duco integration."""

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -1,0 +1,115 @@
+"""Fixtures for Duco tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+from duco.models import BoardInfo, LanInfo, Node, NodeGeneralInfo, NodeVentilationInfo
+import pytest
+
+from homeassistant.components.duco.const import DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+TEST_HOST = "192.168.1.100"
+TEST_MAC = "aa:bb:cc:dd:ee:ff"
+
+USER_INPUT = {CONF_HOST: TEST_HOST}
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        title="SILENT_CONNECT",
+        domain=DOMAIN,
+        data=USER_INPUT,
+        unique_id=TEST_MAC,
+    )
+
+
+@pytest.fixture
+def mock_board_info() -> BoardInfo:
+    """Return mock board info."""
+    return BoardInfo(
+        box_name="SILENT_CONNECT",
+        box_sub_type_name="Eu",
+        serial_board_box="ABC123",
+        serial_board_comm="DEF456",
+        serial_duco_box="GHI789",
+        serial_duco_comm="JKL012",
+        time=1700000000,
+    )
+
+
+@pytest.fixture
+def mock_lan_info() -> LanInfo:
+    """Return mock LAN info."""
+    return LanInfo(
+        mode="WIFI_CLIENT",
+        ip=TEST_HOST,
+        net_mask="255.255.255.0",
+        default_gateway="192.168.1.1",
+        dns="8.8.8.8",
+        mac=TEST_MAC,
+        host_name="duco-box",
+        rssi_wifi=-60,
+    )
+
+
+@pytest.fixture
+def mock_nodes() -> list[Node]:
+    """Return a list with a single BOX node."""
+    return [
+        Node(
+            node_id=1,
+            general=NodeGeneralInfo(
+                node_type="BOX",
+                sub_type=1,
+                network_type="VIRT",
+                parent=0,
+                asso=0,
+                name="Living",
+                identify=0,
+            ),
+            ventilation=NodeVentilationInfo(
+                state="AUTO",
+                time_state_remain=0,
+                time_state_end=0,
+                mode="AUTO",
+                flow_lvl_tgt=0,
+            ),
+        )
+    ]
+
+
+@pytest.fixture
+def mock_duco_client(
+    mock_board_info: BoardInfo,
+    mock_nodes: list[Node],
+) -> Generator[AsyncMock]:
+    """Return a mocked DucoClient."""
+    with patch(
+        "homeassistant.components.duco.DucoClient",
+        autospec=True,
+    ) as mock_class:
+        client = mock_class.return_value
+        client.async_get_board_info = AsyncMock(return_value=mock_board_info)
+        client.async_get_nodes = AsyncMock(return_value=mock_nodes)
+        yield client
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> MockConfigEntry:
+    """Set up the Duco integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -1,0 +1,114 @@
+"""Tests for the Duco config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from duco.exceptions import DucoConnectionError
+
+from homeassistant import config_entries
+from homeassistant.components.duco.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import TEST_MAC, USER_INPUT
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant,
+    mock_board_info,
+    mock_lan_info,
+    mock_duco_client,
+) -> None:
+    """Test a successful user flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.duco.config_flow.DucoClient",
+        autospec=True,
+    ) as mock_class:
+        client = mock_class.return_value
+        client.async_get_board_info = AsyncMock(return_value=mock_board_info)
+        client.async_get_lan_info = AsyncMock(return_value=mock_lan_info)
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], USER_INPUT
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "SILENT_CONNECT"
+    assert result["data"] == USER_INPUT
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].unique_id == TEST_MAC
+
+
+async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
+    """Test handling of a connection error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.duco.config_flow.DucoClient",
+        autospec=True,
+    ) as mock_class:
+        client = mock_class.return_value
+        client.async_get_board_info = AsyncMock(
+            side_effect=DucoConnectionError("Connection refused")
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_flow_duplicate(
+    hass: HomeAssistant,
+    mock_board_info,
+    mock_lan_info,
+    mock_duco_client,
+) -> None:
+    """Test that a duplicate config entry is aborted."""
+    # First config entry
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "homeassistant.components.duco.config_flow.DucoClient",
+        autospec=True,
+    ) as mock_class:
+        client = mock_class.return_value
+        client.async_get_board_info = AsyncMock(return_value=mock_board_info)
+        client.async_get_lan_info = AsyncMock(return_value=mock_lan_info)
+        await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+        await hass.async_block_till_done()
+
+    # Second attempt for the same device
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "homeassistant.components.duco.config_flow.DucoClient",
+        autospec=True,
+    ) as mock_class:
+        client = mock_class.return_value
+        client.async_get_board_info = AsyncMock(return_value=mock_board_info)
+        client.async_get_lan_info = AsyncMock(return_value=mock_lan_info)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], USER_INPUT
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/duco/test_config_flow.py
+++ b/tests/components/duco/test_config_flow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 from duco.exceptions import DucoConnectionError
+from duco.models import BoardInfo, LanInfo
 
 from homeassistant import config_entries
 from homeassistant.components.duco.const import DOMAIN
@@ -16,9 +17,9 @@ from .conftest import TEST_MAC, USER_INPUT
 
 async def test_user_flow_success(
     hass: HomeAssistant,
-    mock_board_info,
-    mock_lan_info,
-    mock_duco_client,
+    mock_board_info: BoardInfo,
+    mock_lan_info: LanInfo,
+    mock_duco_client: AsyncMock,
 ) -> None:
     """Test a successful user flow."""
     result = await hass.config_entries.flow.async_init(
@@ -76,9 +77,9 @@ async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
 
 async def test_user_flow_duplicate(
     hass: HomeAssistant,
-    mock_board_info,
-    mock_lan_info,
-    mock_duco_client,
+    mock_board_info: BoardInfo,
+    mock_lan_info: LanInfo,
+    mock_duco_client: AsyncMock,
 ) -> None:
     """Test that a duplicate config entry is aborted."""
     # First config entry

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -1,0 +1,182 @@
+"""Tests for the Duco fan platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from duco.exceptions import DucoConnectionError
+import pytest
+
+from homeassistant.components.fan import (
+    ATTR_PRESET_MODE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_entity_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that the fan entity is created with the correct state."""
+    entity_id = "fan.living_ventilation"
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON  # fan is always running
+    assert state.attributes["preset_mode"] == "auto"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff_1_ventilation"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_set_preset_mode(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test setting a ventilation preset mode."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {
+            ATTR_ENTITY_ID: "fan.living_ventilation",
+            ATTR_PRESET_MODE: "high",
+        },
+        blocking=True,
+    )
+
+    mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "MAN3")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_turn_on(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test turning on the fan sets medium (MAN2) by default."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "fan.living_ventilation"},
+        blocking=True,
+    )
+
+    mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "MAN2")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_turn_off(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test turning off the fan returns to AUTO mode."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "fan.living_ventilation"},
+        blocking=True,
+    )
+
+    mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "AUTO")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_set_preset_forced(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test setting a forced (CNT) preset sends the right Duco state."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {
+            ATTR_ENTITY_ID: "fan.living_ventilation",
+            ATTR_PRESET_MODE: "medium_forced",
+        },
+        blocking=True,
+    )
+
+    mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "CNT2")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_set_preset_away(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test setting away preset sends EMPT state."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {
+            ATTR_ENTITY_ID: "fan.living_ventilation",
+            ATTR_PRESET_MODE: "away",
+        },
+        blocking=True,
+    )
+
+    mock_duco_client.async_set_ventilation_state.assert_called_once_with(1, "EMPT")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_fan_set_preset_connection_error(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test that a HomeAssistantError is raised on connection failure."""
+    mock_duco_client.async_set_ventilation_state = AsyncMock(
+        side_effect=DucoConnectionError("Connection refused")
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PRESET_MODE,
+            {
+                ATTR_ENTITY_ID: "fan.living_ventilation",
+                ATTR_PRESET_MODE: "low",
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_coordinator_update_marks_unavailable(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test that entities become unavailable when the coordinator fails."""
+    mock_duco_client.async_get_nodes = AsyncMock(
+        side_effect=DucoConnectionError("offline")
+    )
+
+    await hass.config_entries.async_reload(
+        hass.config_entries.async_entries("duco")[0].entry_id
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("fan.living_ventilation")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -1,0 +1,52 @@
+"""Tests for the Duco sensor platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from duco.exceptions import DucoConnectionError
+import pytest
+
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_sensor_entity_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that the sensor entity is created with the correct state."""
+    entity_id = "sensor.living_ventilation_state"
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "AUTO"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff_1_ventilation_state"
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_coordinator_update_marks_unavailable(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test that entities become unavailable when the coordinator fails."""
+    mock_duco_client.async_get_nodes = AsyncMock(
+        side_effect=DucoConnectionError("offline")
+    )
+
+    await hass.config_entries.async_reload(
+        hass.config_entries.async_entries("duco")[0].entry_id
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.living_ventilation_state")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Breaking change

N/A — new integration, no existing functionality affected.

## Proposed change

Add a new **Duco** integration for controlling Duco ventilation systems via the DUCO Connectivity Board. The integration uses the `python-duco-client` library to communicate locally with the board over HTTP.

Supported functionality:
- **Fan entity** with 8 preset modes (auto, away, low, low_forced, medium, medium_forced, high, high_forced) and turn on/off support
- **Sensor entity** exposing the raw ventilation state for use in automations and the logbook

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
